### PR TITLE
Fixed some bugs and added additional config options

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -30,7 +30,11 @@ class AccountsController < ApplicationController
     @account = Account.new(attrs)
     begin
       @account.save!
-      redirect_to login_path, :notice => t(:thanks_for_signing_up_activation_link)
+      if Masquerade::Application::Config['send_activation_mail']
+        redirect_to login_path, :notice => t(:thanks_for_signing_up_activation_link)
+      else
+        redirect_to login_path, :notice => t(:thanks_for_signing_up)
+      end
     rescue ActiveRecord::RecordInvalid
       render :action => 'new'
     end
@@ -67,6 +71,10 @@ class AccountsController < ApplicationController
   end
   
   def activate
+    unless Masquerade::Application::Config['send_activation_mail']
+      return render_404
+    end
+
     begin
       account = Account.find_and_activate!(params[:id])
       redirect_to login_path, :notice => t(:account_activated_login_now)

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -97,6 +97,10 @@ class AccountsController < ApplicationController
   end
   
   def change_password
+    unless Masquerade::Application::Config['can_change_password']
+      return render_404
+    end
+
     if Account.authenticate(current_account.login, params[:old_password])
       if ((params[:password] == params[:password_confirmation]) && !params[:password_confirmation].blank?)
         current_account.password_confirmation = params[:password_confirmation]

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -16,10 +16,17 @@ class AccountsController < ApplicationController
   end
   
   def new
+    if Masquerade::Application::Config['disable_registration']
+      return render_404
+    end
     @account = Account.new
   end
 
   def create
+    if Masquerade::Application::Config['disable_registration']
+      return render_404
+    end
+
     cookies.delete :auth_token
     attrs = params[:account]
 

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -65,6 +65,10 @@ class AccountsController < ApplicationController
   end
 
   def destroy
+    unless Masquerade::Application::Config['can_disable_account']
+      return render_404
+    end
+
     @account = current_account
     if @account.authenticated?(params[:confirmation_password])
       @account.disable!

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -68,7 +68,7 @@ class ApplicationController < ActionController::Base
   end
   
   def render_error(status_code)
-    render :file => "#{Rails.root}/public/#{status_code}.html", :status => status_code
+    render :file => "#{Rails.root}/public/#{status_code}.html", :status => status_code, :layout => false
   end
   
   # Set site locale from

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -4,6 +4,9 @@ class PasswordsController < ApplicationController
 
   # Forgot password
   def create
+    unless Masquerade::Application::Config['can_change_password']
+      return render_404
+    end
     if @account = Account.find_by_email(params[:email], :conditions => 'activation_code IS NULL')
       @account.forgot_password!
       redirect_to login_path, :notice => t(:password_reset_link_has_been_sent)
@@ -15,6 +18,9 @@ class PasswordsController < ApplicationController
   
   # Reset password
   def update
+    unless Masquerade::Application::Config['can_change_password']
+      return render_404
+    end
     unless params[:password].blank?
       if @account.update_attributes(:password => params[:password], :password_confirmation => params[:password_confirmation])
         redirect_to login_path, :notice => t(:password_reset)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,6 +4,9 @@ class SessionsController < ApplicationController
   after_filter :set_login_cookie, :only => :create
   
   def new
+    if logged_in?
+      redirect_after_login
+    end
   end
 
   def create

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -15,7 +15,11 @@ class SessionsController < ApplicationController
       flash[:notice] = t(:you_are_logged_in)
       redirect_after_login
     else
-      redirect_to login_path(:resend_activation_for => params[:login]), :alert => t(:login_incorrect_or_account_not_yet_activated)
+      if Account.find_by_login(params[:login]).nil? or Account.find_by_login(params[:login]).enabled?
+        redirect_to login_path, :alert => t(:login_incorrect)
+      else
+        redirect_to login_path(:resend_activation_for => params[:login]), :alert => t(:login_incorrect_or_account_not_yet_activated)
+      end
     end
   end
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -67,7 +67,7 @@ class Account < ActiveRecord::Base
   
   # Authenticates a user by their login name and password.
   # Returns the user or nil.
-  def self.authenticate(login, password)
+  def self.authenticate(login, password, basic_auth_used=false)
     a = Account.find_by_login(login)
     if a.nil? and Masquerade::Application::Config['create_auth_ondemand']['enabled']
       # Need to set some password - but is never used
@@ -76,7 +76,7 @@ class Account < ActiveRecord::Base
     end
 
     if not a.nil? and a.active? and a.enabled
-      if a.authenticated?(password) or Masquerade::Application::Config['trust_basic_auth']
+      if a.authenticated?(password) or (Masquerade::Application::Config['trust_basic_auth'] and basic_auth_used)
         a.last_authenticated_at, a.last_authenticated_with_yubikey = Time.now, a.authenticated_with_yubikey?
         a.save(:validate => false)
         return a

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -97,7 +97,7 @@ class Account < ActiveRecord::Base
   def authenticated?(password)
     if password.length < 50 && !(yubico_identity? && yubikey_mandatory?) 
       encrypt(password) == crypted_password
-    else
+    elsif Masquerade::Application::Config['can_use_yubikey']
       password, yubico_otp = Account.split_password_and_yubico_otp(password)
       encrypt(password) == crypted_password && @authenticated_with_yubikey = yubikey_authenticated?(yubico_otp)
     end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -71,7 +71,11 @@ class Account < ActiveRecord::Base
     a = Account.find_by_login(login)
     if a.nil? and Masquerade::Application::Config['create_auth_ondemand']['enabled']
       # Need to set some password - but is never used
-      pw = SecureRandom.hex(13)
+      if Masquerade::Application::Config['create_auth_ondemand']['random_password']
+        pw = SecureRandom.hex(13)
+      else
+        pw = password
+      end
       a = Account.create!(:login => login, :password => pw, :password_confirmation => pw, :email => "#{login}@#{Masquerade::Application::Config['create_auth_ondemand']['default_mail_domain']}")
     end
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -95,7 +95,9 @@ class Account < ActiveRecord::Base
   end
   
   def authenticated?(password)
-    if password.length < 50 && !(yubico_identity? && yubikey_mandatory?) 
+    if password.nil?
+      return false
+    elsif password.length < 50 && !(yubico_identity? && yubikey_mandatory?)
       encrypt(password) == crypted_password
     elsif Masquerade::Application::Config['can_use_yubikey']
       password, yubico_otp = Account.split_password_and_yubico_otp(password)

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -181,7 +181,9 @@ class Account < ActiveRecord::Base
   end
   
   def make_activation_code
-    self.activation_code = Digest::SHA1.hexdigest( Time.now.to_s.split(//).sort_by {rand}.join )
+    if Masquerade::Application::Config['send_activation_mail']
+      self.activation_code = Digest::SHA1.hexdigest( Time.now.to_s.split(//).sort_by {rand}.join )
+    end
   end
   
   def make_password_reset_code

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,6 +1,6 @@
 class Account < ActiveRecord::Base
   
-  has_many :personas, :dependent => :destroy, :order => 'id ASC'
+  has_many :personas, :dependent => :delete_all, :order => 'id ASC'
   has_many :sites, :dependent => :destroy
   belongs_to :public_persona, :class_name => "Persona"
 

--- a/app/models/account_mailer.rb
+++ b/app/models/account_mailer.rb
@@ -3,6 +3,7 @@ class AccountMailer < ActionMailer::Base
   default :from => Masquerade::Application::Config['mailer']['from']
 
   def signup_notification(account)
+    raise "send_activation_mail deactivated" unless Masquerade::Application::Config['send_activation_mail']
     @account = account
     mail :to => account.email, :subject => I18n.translate(:please_activate_your_account)
   end

--- a/app/models/account_observer.rb
+++ b/app/models/account_observer.rb
@@ -1,11 +1,15 @@
 class AccountObserver < ActiveRecord::Observer
   
   def after_create(account)
-    AccountMailer.signup_notification(account).deliver
+    if Masquerade::Application::Config['send_activation_mail']
+      AccountMailer.signup_notification(account).deliver
+    else
+      account.send(:activate!)
+    end
+    account.personas.new(:title => "Standard").update_attribute(:deletable, false)
   end
 
   def after_save(account)
-    account.personas.new(:title => "Standard").update_attribute(:deletable, false) if account.pending?
     AccountMailer.forgot_password(account).deliver if account.recently_forgot_password?
   end
   

--- a/app/models/open_id_request.rb
+++ b/app/models/open_id_request.rb
@@ -13,7 +13,9 @@ class OpenIdRequest < ActiveRecord::Base
   
   def from_trusted_domain?
     host = URI.parse(parameters['openid.realm'] || parameters['openid.trust_root']).host
-    Masquerade::Application::Config['trusted_domains'].find { |domain| host.ends_with? domain }
+    unless Masquerade::Application::Config['trusted_domains'].nil?
+      Masquerade::Application::Config['trusted_domains'].find { |domain| host.ends_with? domain }
+    end
   end
 
   private

--- a/app/views/accounts/edit.html.erb
+++ b/app/views/accounts/edit.html.erb
@@ -79,15 +79,18 @@
 <% end %>
 <% end %>
 
-<h2><%=t :disable_my_account %></h2>
+<% if Masquerade::Application::Config['can_disable_account'] %>
+  <h2><%=t :disable_my_account %></h2>
 
-<%= form_tag account_path, :method => :delete do %>
-	<p><%=t :wont_be_possible_to_reclaim_identifier %> <%= identifier(current_account) %></p>
-	<div class="row">
-		<%= label_tag :confirmation_password, t(:confirm_by_entering_password) %>
-  		<%= password_field_tag :confirmation_password, '' %>
-	</div>
-	<div>
-		<%= submit_tag t(:delete_my_account_and_data) %>
-	</div>
+  <%= form_tag account_path, :method => :delete do %>
+    <p><%=t :wont_be_possible_to_reclaim_identifier %> <%= identifier(current_account) %></p>
+    <div class="row">
+      <%= label_tag :confirmation_password, t(:confirm_by_entering_password) %>
+        <%= password_field_tag :confirmation_password, '' %>
+    </div>
+    <div>
+      <%= submit_tag t(:delete_my_account_and_data) %>
+    </div>
+  <% end %>
 <% end %>
+

--- a/app/views/accounts/edit.html.erb
+++ b/app/views/accounts/edit.html.erb
@@ -41,44 +41,46 @@
   <% end %>
 <% end %>
 
-<h2><%=t :my_yubikey %></h2>
-<% if @account.yubico_identity? %>
-<%= form_tag account_yubikey_association_path, :method => :delete do %>
-	<div class="row">
-		<p><%=t :your_account_is_associated_with_the_yubico_identity %> <strong><%= @account.yubico_identity %></strong></p>
-		<p class="note"><%=t :yubikey_how_to_use %></p>
-	</div>
-	<div>
-		<%= submit_tag t(:remove_association) %>
-	</div>
-<% end %>
-
-<%= form_for :account, :url => account_path, :html => { :method => :put } do |f| %>
-	<div>
-	  <p>
-	    <% if @account.yubikey_mandatory? %>
-	     <%=t :your_yubikey_is_mandatory_for_login %>
-	    <% else %>
-	     <%=t :your_yubikey_is_optional_for_login %>
-	    <% end %>
-	  </p>
-    <div>
-      <%= f.hidden_field :yubikey_mandatory, :value => (@account.yubikey_mandatory ? 0 : 1)  %>
-      <%= submit_tag( @account.yubikey_mandatory ? t(:make_my_yubikey_optional) : t(:make_my_yubikey_mandatory) ) %>
+<% if Masquerade::Application::Config['can_use_yubikey'] %>
+  <h2><%=t :my_yubikey %></h2>
+  <% if @account.yubico_identity? %>
+  <%= form_tag account_yubikey_association_path, :method => :delete do %>
+    <div class="row">
+      <p><%=t :your_account_is_associated_with_the_yubico_identity %> <strong><%= @account.yubico_identity %></strong></p>
+      <p class="note"><%=t :yubikey_how_to_use %></p>
     </div>
-	</div>
-<% end %>
+    <div>
+      <%= submit_tag t(:remove_association) %>
+    </div>
+  <% end %>
 
-<% else %>
-<%= form_tag account_yubikey_association_path do %>
-	<div class="row">
-		<%= label_tag :yubico_otp, t(:your_yubikey_a_one_time_password).html_safe %>
-  	<%= password_field_tag :yubico_otp %>
-	</div>
-	<div>
-		<%= submit_tag t(:associate_account_with_yubikey) %>
-	</div>
-<% end %>
+  <%= form_for :account, :url => account_path, :html => { :method => :put } do |f| %>
+    <div>
+      <p>
+        <% if @account.yubikey_mandatory? %>
+         <%=t :your_yubikey_is_mandatory_for_login %>
+        <% else %>
+         <%=t :your_yubikey_is_optional_for_login %>
+        <% end %>
+      </p>
+      <div>
+        <%= f.hidden_field :yubikey_mandatory, :value => (@account.yubikey_mandatory ? 0 : 1)  %>
+        <%= submit_tag( @account.yubikey_mandatory ? t(:make_my_yubikey_optional) : t(:make_my_yubikey_mandatory) ) %>
+      </div>
+    </div>
+  <% end %>
+
+  <% else %>
+  <%= form_tag account_yubikey_association_path do %>
+    <div class="row">
+      <%= label_tag :yubico_otp, t(:your_yubikey_a_one_time_password).html_safe %>
+      <%= password_field_tag :yubico_otp %>
+    </div>
+    <div>
+      <%= submit_tag t(:associate_account_with_yubikey) %>
+    </div>
+  <% end %>
+  <% end %>
 <% end %>
 
 <% if Masquerade::Application::Config['can_disable_account'] %>

--- a/app/views/accounts/edit.html.erb
+++ b/app/views/accounts/edit.html.erb
@@ -20,23 +20,25 @@
   </div>
 <% end %>
 
-<h2><%=t :my_password %></h2>
-<%= form_tag change_password_account_path, :method => :put do %>
-	<div class="row">
-		<%= label_tag :old_password, t(:old_password) %>
-	  <%= password_field_tag :old_password %>
-	</div>
-	<div class="row">
-  	<%= label_tag :password, t(:new_password_minimum_6_characters).html_safe %>
-		<%= password_field_tag :password %>
-	</div>
-	<div class="row">
-		<%= label_tag :password_confirmation, t(:password_confirmation) %>
-		<%= password_field_tag :password_confirmation %>
-	</div>
-	<div>
-		<%= submit_tag t(:submit_update) %>
-	</div>
+<% if Masquerade::Application::Config['can_change_password'] %>
+  <h2><%=t :my_password %></h2>
+  <%= form_tag change_password_account_path, :method => :put do %>
+    <div class="row">
+      <%= label_tag :old_password, t(:old_password) %>
+      <%= password_field_tag :old_password %>
+    </div>
+    <div class="row">
+      <%= label_tag :password, t(:new_password_minimum_6_characters).html_safe %>
+      <%= password_field_tag :password %>
+    </div>
+    <div class="row">
+      <%= label_tag :password_confirmation, t(:password_confirmation) %>
+      <%= password_field_tag :password_confirmation %>
+    </div>
+    <div>
+      <%= submit_tag t(:submit_update) %>
+    </div>
+  <% end %>
 <% end %>
 
 <h2><%=t :my_yubikey %></h2>

--- a/app/views/info/index.html.erb
+++ b/app/views/info/index.html.erb
@@ -1,2 +1,5 @@
 <h2><%=t :get_your_openid %></h2>
-<%= simple_format t(:openid_intro, :signup_link => link_to(t(:signup_for_an_openid), new_account_path)) %>
+<%= simple_format t(:openid_intro) %>
+<% unless Masquerade::Application::Config['disable_registration'] %>
+  <%= simple_format t(:openid_intro_link, :signup_link => link_to(t(:signup_for_an_openid), new_account_path)) %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,7 @@
 		<link rel="icon" href="/favicon.ico" type="image/ico" />
 		<%= stylesheet_link_tag 'application' %>
 		<%= javascript_include_tag 'prototype' %>
+		<%= javascript_include_tag :defaults %>
 	</head>
 	<body>
 		<div id="head">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,7 +27,9 @@
 					<%= nav t(:my_profile), edit_account_path, 'accounts' => ['edit', 'update'] %>
 					<%= nav t(:my_personas), account_personas_path, 'personas' => [] %>
 					<%= nav t(:my_trusted_sites), account_sites_path, 'sites' => [] %>
-					<%= nav t(:logout), logout_path %>
+					<% if not auth_type_used == :basic %>
+						<%= nav t(:logout), logout_path %>
+					<% end %>
 					<% else %>
 					<%= nav t(:current_verification_request), proceed_path, 'server' => [] %>
 					<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,7 +35,9 @@
 					<% end %>
 				<% else %>
 					<%= nav t(:login_link), login_path, 'sessions' => ['new', 'create'] %>
-					<%= nav t(:signup_link), new_account_path, 'accounts' => ['new', 'create'] %>
+					<% unless Masquerade::Application::Config['disable_registration'] %>
+						<%= nav t(:signup_link), new_account_path, 'accounts' => ['new', 'create'] %>
+					<% end %>
 					<%= nav t(:help), help_path, 'info' => ['help'] %>
 				<% end %>
 				</ul>

--- a/app/views/server/seatbelt_config.xml.builder
+++ b/app/views/server/seatbelt_config.xml.builder
@@ -7,11 +7,11 @@ xml.opConfig(:version => '1.0', :serverIdentifier => endpoint_url) do
 	xml.opCertCommonName(Masquerade::Application::Config['ssl_certificate_common_name']) if Masquerade::Application::Config['use_ssl']
 	xml.opCertSHA1Hash(Masquerade::Application::Config['ssl_certificate_sha1']) if Masquerade::Application::Config['use_ssl']
 	xml.loginUrl(login_url(:protocol => scheme))
-	xml.welcomeUrl(home_url(:protocol => scheme))
+	xml.welcomeUrl(root_url(:protocol => scheme))
 	xml.loginStateUrl(seatbelt_state_url(:protocol => scheme, :format => :xml))
-	xml.settingsIconUrl("#{home_url(:protocol => scheme)}images/seatbelt_icon.png")
-  xml.toolbarGrayIconUrl("#{home_url(:protocol => scheme)}images/seatbelt_icon_gray.png")
-  xml.toolbarHighIconUrl("#{home_url(:protocol => scheme)}images/seatbelt_icon_high.png")
+	xml.settingsIconUrl("#{root_url(:protocol => scheme)}images/seatbelt_icon.png")
+	xml.toolbarGrayIconUrl("#{root_url(:protocol => scheme)}images/seatbelt_icon_gray.png")
+	xml.toolbarHighIconUrl("#{root_url(:protocol => scheme)}images/seatbelt_icon_high.png")
 	xml.toolbarGrayBackground('#EBEBEB')
   xml.toolbarGrayBorder('#666666')
   xml.toolbarGrayText('#666666')

--- a/config/app_config.yml.example
+++ b/config/app_config.yml.example
@@ -1,5 +1,15 @@
 --- 
 default: &default
+  send_activation_mail: true
+  trust_basic_auth: false
+  disable_registration: false
+  can_change_password: true
+  can_disable_account: true
+  can_use_yubikey: true
+  create_auth_ondemand:
+    enabled: false
+    default_mail_domain: example.com
+    random_password: true
   name: masquerade
   host: localhost:3000
   email: info@your.domain.com

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -17,6 +17,8 @@ Masquerade::Application.configure do
   # Don't care if the mailer can't send
   config.action_mailer.raise_delivery_errors = false
 
+  config.action_mailer.delivery_method = :smtp
+
   # Print deprecation notices to the Rails logger
   config.active_support.deprecation = :log
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -37,6 +37,8 @@ Masquerade::Application.configure do
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false
 
+  config.action_mailer.delivery_method = :smtp
+
   # Enable threaded mode
   # config.threadsafe!
 

--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -1,4 +1,4 @@
-if ExceptionNotifier
+if Module.const_defined? "ExceptionNotifier"
   Masquerade::Application.config.middleware.use ExceptionNotifier,
     :email_prefix => "[#{Masquerade::Application::Config['name']} Error] ",
     :sender_address => %("#{Masquerade::Application::Config['name']}" <#{Masquerade::Application::Config['mailer']['from']}>),

--- a/config/initializers/mailer.rb
+++ b/config/initializers/mailer.rb
@@ -1,5 +1,4 @@
 # Mailer
-Rails.application.config.action_mailer.delivery_method = :smtp
 Rails.application.config.action_mailer.smtp_settings = {
   :address => Masquerade::Application::Config['mailer']['address'],
   :domain => Masquerade::Application::Config['mailer']['domain'],

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -94,8 +94,8 @@ de:
     digitalen Identität an unterschiedlichen Webseiten anmelden können. Dadurch benötigen Sie nicht mehr für jede Website
     einen eigenen Benutzernamen und Passwort.</p>
     <p>OpenID ist dezentral, kostenlos und ein offener Standard. Es erlaubt Ihnen zu entscheiden, wie viele und welche
-    persönlichen Angaben Sie anderen Webseiten übermitteln.</p>
-    <p>Legen Sie los und %{signup_link}.</p>"
+    persönlichen Angaben Sie anderen Webseiten übermitteln.</p>"
+  openid_intro_link: "<p>Legen Sie los und %{signup_link}.</p>"
   signup_for_an_openid: melden Sie sich für eine OpenID an
   login_to_proceed: Bitte loggen Sie sich ein, um fort zu fahren
   host_requests_identification_you_need_to_login: "%{host} möchte Ihre Identität ermitteln. Dafür müssen Sie sich einloggen."

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -2,6 +2,7 @@ de:
 
   # account controller
   thanks_for_signing_up_activation_link: Danke für Ihre Anmeldung! Wir haben Ihnen eine E-Mail mit einem Aktivierungslink geschickt.
+  thanks_for_signing_up: Danke für Ihre Anmeldung!
   activation_link_resent: Wir haben Ihnen eine E-Mail mit einem Aktivierungslink geschickt.
   profile_updated: Ihr Account wurde aktualisiert.
   account_disabled: Ihr Account wurde deaktiviert.

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -197,6 +197,7 @@ de:
   # sessions controller
   you_are_logged_in: Sie sind jetzt eingeloggt.
   login_incorrect_or_account_not_yet_activated: Die Zugangsdaten sind falsch oder der Account wurde noch nicht aktiviert.
+  login_incorrect: Die Zugangsdaten sind falsch.
   you_are_now_logged_out: Sie sind jetzt ausgeloggt.
 
   # sessions views

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -200,6 +200,7 @@ en:
   # sessions controller
   you_are_logged_in: You are now logged in.
   login_incorrect_or_account_not_yet_activated: The login is incorrect or your account is not activated, yet.
+  login_incorrect: The login is incorrect.
   you_are_now_logged_out: You are now logged out.
 
   # sessions views

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,7 @@ en:
   
   # account controller
   thanks_for_signing_up_activation_link: Thank you for signing up! We sent you an email containing an activation link.
+  thanks_for_signing_up: Thank you for signing up!
   activation_link_resent: We sent you an email containing an activation link.
   profile_updated: Your profile has been updated.
   account_disabled: Your account has been disabled.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,8 +98,8 @@ en:
     web sites using a single digital identity, eliminating the need for different user names
     and passwords for each site.</p>
     <p>OpenID is a decentralized, free and open standard that lets you control the amount of 
-    personal information that you would like to provide to other web sites.</p>
-    <p>Get started and %{signup_link}.</p>"
+    personal information that you would like to provide to other web sites.</p>"
+  openid_intro_link: "<p>Get started and %{signup_link}.</p>"
   signup_for_an_openid: signup for an OpenID
   login_to_proceed: Please log in to proceed
   host_requests_identification_you_need_to_login: "%{host} requests your identification and you need to log in to proceed."

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -5,6 +5,7 @@ es:
   
   # account controller
   thanks_for_signing_up_activation_link: Gracias por registrarte! Te hemos enviado un correo con un enlace para que actives tu cuenta.
+  thanks_for_signing_up: Gracias por registrarte!
   profile_updated: Tu perfil a sido actualizado.
   account_disabled: Tu cuenta a sido desabilitada.
   entered_password_is_wrong: La clave ingresada es incorrecta.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -83,8 +83,8 @@ es:
     utilizando una sola identidad digital, eliminando la necesidad de distintos nombres de usuarios 
     y contraseñas para cada sitio</p>
     <p>OpenID es descentralizado, gratis y un estandar abierto, que te permite controlar la 
-    cantidad de información personal que deseas entregar a cada sitio</p>
-    <p>Empieza a usarlo y %{signup_link}.</p>"
+    cantidad de información personal que deseas entregar a cada sitio</p>"
+  openid_intro_link: "<p>Empieza a usarlo y %{signup_link}.</p>"
   signup_for_an_openid: registrate por tu OpenID
   login_to_proceed: Por favor ingresa para continuar
   host_requests_identification_you_need_to_login: 

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -189,6 +189,7 @@ es:
   # sessions controller
   you_are_logged_in: Ahora estás ingresado.
   login_incorrect_or_account_not_yet_activated: El usuario es incorrecto o la cuenta no ha sido activada todavía.
+  login_incorrect: El usuario es incorrecto.
   you_are_now_logged_out: Has salido.
 
   # sessions views

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -5,6 +5,7 @@ nl:
   
   # account controller
   thanks_for_signing_up_activation_link: Bedankt voor het aanmelden! We hebben u een mail gestuurd met een activatielink.
+  thanks_for_signing_up: Bedankt voor het aanmelden!
   profile_updated: Uw profiel werd bijgewerkt.
   account_disabled: Uw account has werd uitgezet.
   entered_password_is_wrong: Het ingevoerde wachtwoord is fout.

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -86,8 +86,8 @@ nl:
   get_your_openid: Maak een OpenID
   openid_intro: "<p>OpenID is een gedeelde identiteitsdienst, waarmee je kunt inloggen op veel verschillende
   websites met één enkele identiteit. Het is niet langer nodig verschillende gebruikersnamen en wachtwoorden voor elke site te hebben.</p>
-    <p>OpenID is een gedecentraliseerde, vrije en open standaard waarmee u zelf bepaalt hoeveel persoonlijke informatie wordt doorgegeven aan andere websites.</p>
-    <p>Begin hier and %{signup_link}.</p>"
+    <p>OpenID is een gedecentraliseerde, vrije en open standaard waarmee u zelf bepaalt hoeveel persoonlijke informatie wordt doorgegeven aan andere websites.</p>"
+  openid_intro_link: "<p>Begin hier and %{signup_link}.</p>"
   signup_for_an_openid: maak een OpenID aan
   login_to_proceed: Logt u alstublieft in om verder te gaan
   host_requests_identification_you_need_to_login: "%{host} vraagt uw identificatie. U moet inloggen om verder te gaan."

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -187,6 +187,7 @@ nl:
   # sessions controller
   you_are_logged_in: U bent nu ingelogd.
   login_incorrect_or_account_not_yet_activated: De inloggegevens zijn incorrect of uw account is nog niet geactiveerd.
+  login_incorrect: De inloggegevens zijn incorrect.
   you_are_now_logged_out: U bent nu uitgelogd.
 
   # sessions views

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,17 +5,13 @@ Masquerade::Application.routes.draw do
     get :password
     put :change_password
     
-    resources :personas do
-      resources :properties
-    end
-    resources :sites do
-      resources :release_policies
-    end
-    resource :yubikey_association
+    resources :personas
+    resources :sites
+    resource :yubikey_association, :only => [:create, :destroy]
   end
 
-  resource :session
   resource :password
+  resource :session, :only => [:new, :create, :destroy]
   
   get "/help" => "info#help", :as => :help
   get "/safe-login" => "info#safe_login", :as => :safe_login

--- a/lib/authenticated_system.rb
+++ b/lib/authenticated_system.rb
@@ -110,7 +110,7 @@ module AuthenticatedSystem
     # Called from #current_account.  Now, attempt to login by basic authentication information.
     def login_from_basic_auth
       authenticate_with_http_basic do |accountname, password|
-        account = Account.authenticate(accountname, password)
+        account = Account.authenticate(accountname, password, true)
         self.auth_type_used = :basic if not account.nil?
         self.current_account = account
         account

--- a/login.dot
+++ b/login.dot
@@ -1,0 +1,72 @@
+/* TODO borders on subgraph - doesn't work */
+digraph masquerade_auth {
+  subgraph authenticate {
+    label="authenticate"
+    color = purple;
+
+    "account exist?" -> "account active?" [label="yes"];
+    "account exist?" -> "create_auth_ondemand" [label="no"];
+
+    "account active?" -> "account enabled?" [label="yes"];
+    "account active?" -> "failure" [label="no"];
+
+    "account enabled?" -> "password.nil?" [label="yes"];
+    "account enabled?" -> "failure" [label="no"];
+
+
+    subgraph create_acc_on_demand {
+      label = "create account";
+      color = purple;
+
+      "create_auth_ondemand" -> "random_password" [label="enabled"];
+      "create_auth_ondemand" -> "failure" [label="disabled"];
+
+      "random_password" -> "generate random password" [label="enabled"];
+      "random_password" -> "use incomming password" [label="disabled"];
+
+      "generate random password" -> "account active?";
+      "use incomming password" -> "account active?";
+    }
+
+    subgraph authenticated {
+      label = "authenticated?";
+      color = purple;
+
+      "password.nil?" -> "authenticated failure" [label="yes"];
+      "password.nil?" -> "password.length < 50?" [label="no"];
+
+      "password.length < 50?" -> "yubico_identity?" [label="yes"];
+      "password.length < 50?" -> "encrypted password matches saved?" [label="no"];
+
+      subgraph yubico {
+        label = "yubico";
+        color = purple;
+
+        "yubico_identity?" -> "yubikey_mandatory?" [label="yes"];
+        "yubico_identity?" -> "encrypted password matches saved?" [label="no"];
+
+        "yubikey_mandatory?" -> "can_use_yubikey" [label="yes"];
+        "yubikey_mandatory?" -> "encrypted password matches saved?" [label="no"];
+
+        "can_use_yubikey" -> "yubikey_authenticated?" [label="yes"];
+        "can_use_yubikey" -> "authenticated failure" [label="no"];
+
+        "yubikey_authenticated?" -> "encrypted password matches saved?" [label="yes"];
+        "yubikey_authenticated?" -> "authenticated failure" [label="no"];
+      }
+
+      "encrypted password matches saved?" -> "authenticated success" [label="yes"];
+      "encrypted password matches saved?" -> "authenticated failure" [label="no"];
+    }
+
+    "authenticated failure" -> "trust_basic_auth"
+    "authenticated success" -> "success"
+
+    "trust_basic_auth" -> "basic_auth_used" [label="enabled"]
+    "trust_basic_auth" -> "failure" [label="disabled"]
+
+    "basic_auth_used" -> "success" [label="yes"]
+    "basic_auth_used" -> "failure" [label="no"]
+  }
+
+}

--- a/test/functional/accounts_controller_test.rb
+++ b/test/functional/accounts_controller_test.rb
@@ -66,14 +66,23 @@ class AccountsControllerTest < ActionController::TestCase
     assert_login_required
   end
   
-  def test_should_disable_account_if_confirmation_password_matches
+  def test_should_disable_account_if_confirmation_password_matches_and_can_disable_account_is_enabled
+    Masquerade::Application::Config['can_disable_account'] = true
     login_as(:standard)
     delete :destroy, :confirmation_password => 'test'
     assert !accounts(:standard).reload.enabled
     assert_redirected_to root_url
   end
+
+  def test_should_get_404_on_disable_account_if_confirmation_password_matches_and_can_disable_account_is_disabled
+    Masquerade::Application::Config['can_disable_account'] = false
+    login_as(:standard)
+    delete :destroy, :confirmation_password => 'test'
+    assert_response :not_found
+  end
   
   def test_should_not_disable_account_if_confirmation_password_does_not_match
+    Masquerade::Application::Config['can_disable_account'] = true # doesn't make sense if registration is disabled
     login_as(:standard)
     delete :destroy, :confirmation_password => 'lksdajflsaf'
     assert accounts(:standard).reload.enabled

--- a/test/functional/accounts_controller_test.rb
+++ b/test/functional/accounts_controller_test.rb
@@ -88,6 +88,20 @@ class AccountsControllerTest < ActionController::TestCase
     assert accounts(:standard).reload.enabled
     assert_redirected_to edit_account_url
   end
+
+  def test_should_show_disable_account_if_can_disable_account_is_enabled
+    Masquerade::Application::Config['can_disable_account'] = true
+    login_as(:standard)
+    get :edit
+    assert_select "h2:nth-of-type(4)", I18n.t(:disable_my_account)
+  end
+
+  def test_should_not_show_disable_account_if_can_disable_account_is_disabled
+    Masquerade::Application::Config['can_disable_account'] = false
+    login_as(:standard)
+    get :edit
+    assert_select "h2:nth-of-type(4)", {:text => I18n.t(:disable_my_account), :count => 0}
+  end
   
   def test_should_set_yadis_header_on_identity_page
     account = accounts(:standard).login

--- a/test/functional/accounts_controller_test.rb
+++ b/test/functional/accounts_controller_test.rb
@@ -4,11 +4,20 @@ class AccountsControllerTest < ActionController::TestCase
   
   fixtures :accounts
   
-  def test_should_allow_signup
+  def test_should_allow_signup_if_enabled
+    Masquerade::Application::Config['disable_registration'] = false
     assert_difference 'Account.count' do
       post :create, :account => valid_account_attributes
     end  
     assert_redirected_to login_path
+  end
+
+  def test_should_return404_on_signup_if_disabled
+    Masquerade::Application::Config['disable_registration'] = true
+    get :new
+    assert_response :not_found
+    post :create, :account => valid_account_attributes
+    assert_response :not_found
   end
 
   def test_should_show_correct_message_after_signup_if_send_activation_mail_is_disabled

--- a/test/functional/accounts_controller_test.rb
+++ b/test/functional/accounts_controller_test.rb
@@ -11,6 +11,32 @@ class AccountsControllerTest < ActionController::TestCase
     assert_redirected_to login_path
   end
 
+  def test_should_show_correct_message_after_signup_if_send_activation_mail_is_disabled
+    Masquerade::Application::Config['disable_registration'] = false # doesn't make sense if registration is disabled
+    Masquerade::Application::Config['send_activation_mail'] = true
+    post :create, :account => valid_account_attributes
+    assert_equal I18n.t(:thanks_for_signing_up_activation_link), flash[:notice]
+  end
+
+  def test_should_show_correct_message_after_signup_if_send_activation_mail_is_enabled
+    Masquerade::Application::Config['disable_registration'] = false # doesn't make sense if registration is disabled
+    Masquerade::Application::Config['send_activation_mail'] = false
+    post :create, :account => valid_account_attributes
+    assert_equal I18n.t(:thanks_for_signing_up), flash[:notice]
+  end
+
+  def test_should_allow_activate_if_send_activation_mail_is_enabled
+    Masquerade::Application::Config['send_activation_mail'] = true
+    get :activate, :account => valid_account_attributes
+    assert_response :found
+  end
+
+  def test_should_return404_activate_if_send_activation_mail_is_disabled
+    Masquerade::Application::Config['send_activation_mail'] = false
+    get :activate, :account => valid_account_attributes
+    assert_response :not_found
+  end
+
   def test_should_require_login_for_edit
     get :edit
     assert_login_required

--- a/test/functional/info_controller_test.rb
+++ b/test/functional/info_controller_test.rb
@@ -1,10 +1,35 @@
 require 'test_helper'
 
 class InfoControllerTest < ActionController::TestCase
-  
   def test_should_set_yadis_header_on_homepage
     get :index
     assert_match server_url(:format => :xrds), @response.headers['X-XRDS-Location']
   end
-  
+
+  def test_should_show_registration_link_if_enabled
+    Masquerade::Application::Config['disable_registration'] = false
+    get :index
+    assert_select "ul#navi li a", {:text => I18n.t(:signup_link), :count => 1}
+  end
+
+  def test_should_not_show_registration_link_if_disabled
+    Masquerade::Application::Config['disable_registration'] = true
+    get :index
+    assert_select "ul#navi li a", {:text => I18n.t(:signup_link), :count => 0}
+  end
+
+  def test_should_not_show_registration_link_on_index_if_disable_registration_is_enabled
+    Masquerade::Application::Config['disable_registration'] = false
+    get :index
+    text = I18n.t(:openid_intro_link, :signup_link => I18n.t(:signup_for_an_openid))
+    text = text[3..-5] # cut <p> and </p> -- ugly :(
+    assert_select "p:nth-child(3)", {:text => text, :count => 1}
+  end
+
+  def test_should_show_registration_link_on_index_if_disable_registration_is_disabled
+    Masquerade::Application::Config['disable_registration'] = true
+    get :index
+    assert_select "p:nth-child(3)", {:text => I18n.t(:openid_intro_link, :signup_link => I18n.t(:signup_for_an_openid)), :count => 0}
+  end
+
 end

--- a/test/functional/info_controller_test.rb
+++ b/test/functional/info_controller_test.rb
@@ -32,4 +32,27 @@ class InfoControllerTest < ActionController::TestCase
     assert_select "p:nth-child(3)", {:text => I18n.t(:openid_intro_link, :signup_link => I18n.t(:signup_for_an_openid)), :count => 0}
   end
 
+  def test_should_show_logout_link_after_cookie_login
+    accounts(:standard).remember_me
+    @request.cookies["auth_token"] = accounts(:standard).remember_token
+    get :index
+    assert @controller.send(:logged_in?)
+    assert_select "ul#navi li a", {:text => I18n.t(:logout), :count => 1}
+  end
+
+  def test_should_show_logout_link_after_session_login
+    login_as :standard
+    get :index
+    assert @controller.send(:logged_in?)
+    assert_select "ul#navi li a", {:text => I18n.t(:logout), :count => 1}
+  end
+
+  def test_should_not_show_logout_link_after_basic_login
+    @request.env['HTTP_AUTHORIZATION'] = encode_credentials(accounts(:standard).login, 'test')
+    get :index
+    assert @controller.send(:logged_in?)
+    assert @controller.send(:auth_type_used) == :basic
+    assert_select "ul#navi li a", {:text => I18n.t(:logout), :count => 0}
+  end
+
 end

--- a/test/functional/passwords_controller_test.rb
+++ b/test/functional/passwords_controller_test.rb
@@ -10,19 +10,29 @@ class PasswordsControllerTest < ActionController::TestCase
   end
   
   def test_should_display_error_when_email_could_not_be_found
+    Masquerade::Application::Config['can_change_password'] = true # makes no sense without
     post :create, :email => 'doesnotexist@somewhere.com'
     assert flash[:alert]
     assert_template 'new'
   end
   
   def test_should_reset_password_when_email_could_be_found
+    Masquerade::Application::Config['can_change_password'] = true # makes no sense without
     @account = accounts(:standard)
     post :create, :email => @account.email
     assert_not_nil @account.reload.password_reset_code
     assert_redirected_to login_url
     assert flash[:notice]
   end
-  
+
+  def test_should_return404_on_reset_password_when_can_change_password_is_disabled
+    Masquerade::Application::Config['can_change_password'] = false
+    @account = accounts(:standard)
+    post :create, :email => @account.email
+    assert_nil @account.reload.password_reset_code
+    assert_response :not_found
+  end
+
   # def test_should_redirect_to_new_if_code_is_missing
   #   get :edit
   #   assert_redirected_to forgot_password_path
@@ -36,6 +46,7 @@ class PasswordsControllerTest < ActionController::TestCase
   # end
   
   def test_should_reset_the_password_when_it_matches_confirmation
+    Masquerade::Application::Config['can_change_password'] = true # makes no sense without
     @account = accounts(:standard)
     old_crypted_password = @account.crypted_password
     @account.forgot_password!
@@ -46,8 +57,21 @@ class PasswordsControllerTest < ActionController::TestCase
     assert_redirected_to login_url
     assert flash[:notice]
   end
-  
+
+  def test_should_not_reset_the_password_when_can_change_password_is_disabled
+    Masquerade::Application::Config['can_change_password'] = false
+    @account = accounts(:standard)
+    old_crypted_password = @account.crypted_password
+    @account.forgot_password!
+    put :update, :id => @account.password_reset_code,
+      :password => 'v4l1d_n3w_pa$$w0rD',
+      :password_confirmation => 'v4l1d_n3w_pa$$w0rD'
+    assert_equal old_crypted_password, @account.reload.crypted_password
+    assert_response :not_found
+  end
+
   def test_should_not_reset_the_password_if_it_is_blank
+    Masquerade::Application::Config['can_change_password'] = true # makes no sense without
     @account = accounts(:standard)
     old_crypted_password = @account.crypted_password
     @account.forgot_password!
@@ -61,6 +85,7 @@ class PasswordsControllerTest < ActionController::TestCase
   end
   
   def test_should_not_reset_the_password_if_it_does_not_match_confirmation
+    Masquerade::Application::Config['can_change_password'] = true # makes no sense without
     @account = accounts(:standard)
     old_crypted_password = @account.crypted_password
     @account.forgot_password!

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -15,6 +15,13 @@ class SessionsControllerTest < ActionController::TestCase
     assert_redirected_to identity_url(account)
   end
 
+  def test_should_redirect_to_users_on_login_if_allready_logged_in
+    login_as :standard
+    account = accounts(:standard)
+    get :new
+    assert_redirected_to identity_url(account)
+  end
+
   def test_should_set_cookie_with_auth_token_if_user_chose_to_be_remembered
     post :create, :login => accounts(:standard).login, :password => 'test', :remember_me => "1"
     assert_not_nil @response.cookies["auth_token"]

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -37,6 +37,33 @@ class SessionsControllerTest < ActionController::TestCase
     assert_nil session[:account_id]
   end
 
+  def test_should_not_save_account_id_in_session_after_basic_login
+    @request.env['HTTP_AUTHORIZATION'] = encode_credentials(accounts(:standard).login, 'test')
+    post :new
+    assert_nil session[:account_id]
+    assert @controller.send(:logged_in?)
+    assert @controller.send(:auth_type_used) == :basic
+  end
+
+  def test_should_set_correct_auth_type_on_basic_login
+    @request.env['HTTP_AUTHORIZATION'] = encode_credentials(accounts(:standard).login, 'test')
+    get :new
+    assert @controller.send(:auth_type_used) == :basic
+  end
+
+  def test_should_set_correct_auth_type_on_login_with_session
+    login_as :standard
+    get :new
+    assert @controller.send(:auth_type_used) == :session
+  end
+
+  def test_should_set_correct_auth_type_on_login_with_cookie
+    accounts(:standard).remember_me
+    @request.cookies["auth_token"] = cookie_for(:standard)
+    get :new
+    assert @controller.send(:auth_type_used) == :cookie
+  end
+
   def test_should_redirect_to_login_after_failed_login
     post :create, :login => accounts(:standard).login, :password => 'bad password'
     assert_redirected_to login_path

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -133,4 +133,9 @@ class ActiveSupport::TestCase
     assert_not_nil @request.session[:return_to]
   end
   
+  # verbatim, from ActiveController's own unit tests
+  # stolen from http://stackoverflow.com/questions/1165478/testing-http-basic-auth-in-rails-2-2/1258046#1258046
+  def encode_credentials(username, password)
+    "Basic #{ActiveSupport::Base64.encode64("#{username}:#{password}")}"
+  end
 end

--- a/test/unit/account_mailer_test.rb
+++ b/test/unit/account_mailer_test.rb
@@ -2,19 +2,27 @@ require 'test_helper'
 require 'account_mailer'
 
 class AccountMailerTest < ActiveSupport::TestCase
-  
-  def setup
+  def test_should_send_signup_notification_if_send_notification_mail_option_is_enabled
+    Masquerade::Application::Config['send_activation_mail'] = true
     @account = Account.create valid_account_attributes
-  end
-  
-  def test_should_send_signup_notification
+
     response = AccountMailer.signup_notification(@account)
     assert_equal @account.email, response.to[0]
     assert response.parts.size == 2
     response.parts.each { |part| assert part.body.match(@account.activation_code) }
   end
-  
+
+  def test_should_not_send_signup_notification_if_send_notification_mail_option_is_disabled
+    Masquerade::Application::Config['send_activation_mail'] = false
+    @account = Account.create valid_account_attributes
+
+    assert_raise RuntimeError, "send_activation_mail deactivated" do
+      AccountMailer.signup_notification(@account)
+    end
+  end
+
   def test_should_send_forgot_password
+    @account = Account.create valid_account_attributes
     @account.forgot_password!
     response = AccountMailer.forgot_password(@account)
     assert_equal @account.email, response.to[0]

--- a/test/unit/account_test.rb
+++ b/test/unit/account_test.rb
@@ -145,8 +145,10 @@ class AccountTest < ActiveSupport::TestCase
   
   def test_should_delete_associated_personas_on_destroy
     @account.save
-    @persona = @account.personas.create(valid_persona_attributes)
+    # one default persona
     assert_equal 1, @account.personas.size
+    @persona = @account.personas.create(valid_persona_attributes)
+    assert_equal 2, @account.personas.size
     @account.destroy
     assert_nil Persona.find_by_id(@persona.id)
   end

--- a/test/unit/account_test.rb
+++ b/test/unit/account_test.rb
@@ -76,9 +76,16 @@ class AccountTest < ActiveSupport::TestCase
     assert_valid @account
   end
   
-  def test_should_assign_activation_code_on_create
+  def test_should_assign_activation_code_on_create_if_send_activation_mail_is_enabled
+    Masquerade::Application::Config['send_activation_mail'] = true
     @account.save
     assert_not_nil @account.activation_code
+  end
+
+  def test_should_not_assign_activation_code_on_create_if_send_activation_mail_is_disabled
+    Masquerade::Application::Config['send_activation_mail'] = false
+    @account.save
+    assert_nil @account.activation_code
   end
   
   def test_should_find_and_activate_by_activation_token


### PR DESCRIPTION
Hi,

I fixed some bugs in masquerade:
- 4df00a733c2c33ba1781edcf40ad395b1364060c
- 0ceda867685f588a3f6e528f897ecc3fb495d28c
- 0927ef8fe6559c9ec02c453f1764bbd0faeb9a6c
- 1741417641342e1c9a79112219c627152e9c6f6c
- 9e7282ba6f62c717f612aabbe8f4f64686146ee0
- 3f9a3c9b0381acb0b97d10a1c8360f82747a09fc
- a69a185cc16d3f02e4dc6742792941f37aac981d

Additionally I want no auth in masquerade. My apache2 server implements a single sign login for all sites  so I made some commits to support this:
- 9cc8f52646e63fd30c3283c6dedd23ed69451c8d - no activation mail
- eb6ef1b200235bdfacd36c76f6351088c81e2238 - Don't set account_id cookie if basic_auth is used
- 760f941a84e9d37203cca629b412ca7241c0088b - Added option to disable registration
- 1428cdd8bdbb1b9a06e7e8ccc99dfafc8f1fd19b - Added option to forbid a user to disable the account
- 89ddbb5603e843bd2cfb349c2b237f7c77b2b4e9 - Added option to forbid user to change the password
- 9299afaa64680aa230f82cd63755bf5bd9f8adb2 - Add config option to disable yubikey

Important is the commit to trust the basic auth and don't check the password in masquerade database. Also a account can be created on demand if create_auth_ondemand is set.
- 9ed4c09331c721f3731365882fe265610eb8bf1d

Finally I hide the logout link if user is logged in via auth_basic:
- 75779ce7141ebcdecd9a9b9f0ddaf04836b59702

One last problem exists: I don't know how to enable read access to account page (and xrds). Currently I forbid all access and whitelist the required links:

```
< Location "/" >
  AuthName "login"
  AuthType Basic
  require group openid
  ...
< /Location >

< LocationMatch "^/(consumer|server|stylesheets|images|javascripts|help|logout|404.html|422.html|500.html|favicon.ico|robots.txt|safe-login)" >
  Order Allow,Deny
  Allow from all
  Satisfy Any
< /LocationMatch >

< LocationMatch "^/$" >
  Order Allow,Deny
  Allow from all
  Satisfy Any
< /LocationMatch >
```

But I need to enable /username(.xrds) as well for GET requests. But I don't want to write all usernames down. Do you have any ideas? My suggestion is to move /username(.xrds) to /users/username(.xrds) than a whitelist for /users/\* would be possible. What do you think?

Greetings,
nougad
